### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ On Ubuntu system:
 ```
 $ sudo apt remove fprintd
 $ sudo add-apt-repository ppa:uunicorn/open-fprintd
-$ sudo aptget update
-$ sudo apt install open-fprintd fprintd-clients python-validity
+$ sudo apt-get update
+$ sudo apt install open-fprintd fprintd-clients python3-validity
 ...wait a bit...
 $ fprintd-enroll
 ```


### PR DESCRIPTION
This makes all the commands not throw syntax errors or package not found. However, for 009a, fprintd-enroll still says list_devices failed: