### PR TITLE
Update python3-validity-suspend-restart.service

### DIFF
--- a/debian/python3-validity-suspend-restart.service
+++ b/debian/python3-validity-suspend-restart.service
@@ -1,11 +1,10 @@
 [Unit]
 Description=Restart python-validity after resume
-After=suspend.target hibernate.target hybrid-sleep.target
+After=suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
 
 [Service]
 Type=simple
 ExecStart=/bin/systemctl --no-block restart python3-validity.service
 
 [Install]
-WantedBy=suspend.target hibernate.target hybrid-sleep.target
-
+WantedBy=suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target


### PR DESCRIPTION
Systemd uses additional target corelated to resume - suspend-then-hibernate.target