### PR TITLE
suppress dbus lib  warnings + warn against no indent in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ user_to_sid:
     "myusername": "S-1-5-21-1234567890-1234567890-1234567890-1001"
     "someotheruser": "S-1-5-21-1234567890-1234567890-1234567890-1003"
 ```
+Note the indentation; each entry has to be preceded by at least one space.
 
 ## Playground
 

--- a/dbus_service/dbus-service
+++ b/dbus_service/dbus-service
@@ -30,7 +30,6 @@ from validitysensor.usb import usb
 from validitysensor.winbio_constants import finger_ids
 
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-GLib.threads_init()
 
 INTERFACE_NAME = 'io.github.uunicorn.Fprint.Device'
 
@@ -242,7 +241,7 @@ def main():
     # Load and perform basic validation of config file.
     try:
         with (args.configpath / 'dbus-service.yaml').open(mode='rt') as configfd:
-            config = yaml.load(configfd)
+            config = yaml.load(configfd, Loader=yaml.BaseLoader)
     except FileNotFoundError:
         # No configuration file. Create default
         config = {'user_to_sid': {}}


### PR DESCRIPTION
It has taken me few hours to realize YAML requires indentation in the config file..
Since bad file (no indents) is still valid YAML, there won't be any warning. Therefore I'm for this note in README..


Regarding warning suppression: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation