### PR TITLE
Unsafe load() call disabled by Gentoo. See bug #659348

### DIFF
--- a/dbus_service/dbus-service
+++ b/dbus_service/dbus-service
@@ -241,7 +241,7 @@ def main():
     # Load and perform basic validation of config file.
     try:
         with (args.configpath / 'dbus-service.yaml').open(mode='rt') as configfd:
-            config = yaml.load(configfd, Loader=yaml.BaseLoader)
+            config = yaml.safe_load(configfd, Loader=yaml.BaseLoader)
     except FileNotFoundError:
         # No configuration file. Create default
         config = {'user_to_sid': {}}


### PR DESCRIPTION
```
Aug 02 20:42:54 t480 dbus-service[60937]: Traceback (most recent call last):
Aug 02 20:42:54 t480 dbus-service[60937]:   File "/usr/lib/python-validity/dbus-service", line 307, in <module>
Aug 02 20:42:54 t480 dbus-service[60937]:     main()
Aug 02 20:42:54 t480 dbus-service[60937]:   File "/usr/lib/python-validity/dbus-service", line 245, in main
Aug 02 20:42:54 t480 dbus-service[60937]:     config = yaml.load(configfd)
Aug 02 20:42:54 t480 dbus-service[60937]:   File "/usr/lib/python3.9/site-packages/yaml/__init__.py", line 109, in load
Aug 02 20:42:54 t480 dbus-service[60937]:     raise RuntimeError("Unsafe load() call disabled by Gentoo. See bug #659348")
Aug 02 20:42:54 t480 dbus-service[60937]: RuntimeError: Unsafe load() call disabled by Gentoo. See bug #659348
```

Relevant Gentoo bug report https://bugs.gentoo.org/659348

Replacing yaml.load() calls with yaml.safe_load() should fix it