### PR TITLE
update dbus-loader: Remove Loader from safe_load()

### DIFF
--- a/dbus_service/dbus-service
+++ b/dbus_service/dbus-service
@@ -241,7 +241,7 @@ def main():
     # Load and perform basic validation of config file.
     try:
         with (args.configpath / 'dbus-service.yaml').open(mode='rt') as configfd:
-            config = yaml.safe_load(configfd, Loader=yaml.BaseLoader)
+            config = yaml.safe_load(configfd)
     except FileNotFoundError:
         # No configuration file. Create default
         config = {'user_to_sid': {}}


### PR DESCRIPTION
As I commented on the commit c0bf88e, https://github.com/uunicorn/python-validity/commit/c0bf88ea050c446dc12d81a0de8d30a4f81cc797
python3-validity.service does not start, at least on Debian buster, since
safe_load() does not have arg Loader on its prototype.
Removing Loader here,
config = yaml.safe_load(configfd)
makes it back to normal starting.