### PR TITLE
Move write paths to /var/run/python-validity

### DIFF
--- a/bin/validity-sensors-firmware
+++ b/bin/validity-sensors-firmware
@@ -32,7 +32,7 @@ from usb import core as usb_core
 from validitysensor.firmware_tables import FIRMWARE_NAMES, FIRMWARE_URIS
 from validitysensor.usb import SupportedDevices
 
-python_validity_data = '/usr/share/python-validity/'
+python_validity_data = '/var/run/python-validity/'
 
 
 def download_and_extract_fw(dev_type, fwdir, fwuri=None):

--- a/dbus_service/dbus-service
+++ b/dbus_service/dbus-service
@@ -191,7 +191,7 @@ class Device(dbus.service.Object):
         return hexlify(tls.app(unhexlify(cmd))).decode()
 
 
-backoff_file = '/usr/share/python-validity/backoff'
+backoff_file = '/var/run/python-validity/backoff'
 
 
 # I don't know how to tell systemd to backoff in case of multiple instance of the same template service, help!

--- a/debian/python3-validity.postinst
+++ b/debian/python3-validity.postinst
@@ -4,6 +4,7 @@ set -e
 #DEBHELPER#
 
 if [ "$1" = "configure" ]; then
+    mkdir -p /var/run/python-validity || true
     validity-sensors-firmware || true
     systemctl daemon-reload || true
     udevadm control --reload-rules || true

--- a/validitysensor/sensor.py
+++ b/validitysensor/sensor.py
@@ -20,7 +20,7 @@ from .usb import usb, CancelledException
 from .util import assert_status, unhex
 
 # TODO: this should be specific to an individual device (system may have more than one sensor)
-calib_data_path = '/usr/share/python-validity/calib-data.bin'
+calib_data_path = '/var/run/python-validity/calib-data.bin'
 
 line_update_type1_devices = [
     0xB5, 0x885, 0xB3, 0x143B, 0x1055, 0xE1, 0x8B1, 0xEA, 0xE4, 0xED, 0x1825, 0x1FF5, 0x199

--- a/validitysensor/upload_fwext.py
+++ b/validitysensor/upload_fwext.py
@@ -8,7 +8,7 @@ from .flash import write_flash_all, write_fw_signature, get_fw_info
 from .sensor import reboot, write_hw_reg32, read_hw_reg32, identify_sensor
 from .usb import usb, SupportedDevices
 
-firmware_home = '/usr/share/python-validity'
+firmware_home = '/var/run/python-validity'
 
 
 def default_fwext_name():


### PR DESCRIPTION
As mentioned in issue #95 python-validity currently doesn't work on Fedora Silverblue, due to the /usr folder being read-only.
As I just hit that issue myself, I tried fixing it with the comments from #92 in mind.

I am not sure if the Debian part is acceptable and I don't know if I've missed something else, so I'm open to comments.