### PR TITLE
Fix issue where /var/lib/python-validity doesn't exist on daemon startup

### DIFF
--- a/bin/validity-sensors-firmware
+++ b/bin/validity-sensors-firmware
@@ -29,10 +29,10 @@ import urllib.request
 
 from usb import core as usb_core
 
+from validitysensor.init_data_dir import PYTHON_VALIDITY_DATA_DIR
 from validitysensor.firmware_tables import FIRMWARE_NAMES, FIRMWARE_URIS
 from validitysensor.usb import SupportedDevices
 
-python_validity_data = '/var/run/python-validity/'
 
 
 def download_and_extract_fw(dev_type, fwdir, fwuri=None):
@@ -99,4 +99,4 @@ if __name__ == "__main__":
 
     with tempfile.TemporaryDirectory() as fwdir:
         fwpath = download_and_extract_fw(dev_type, fwdir, fwuri=args.driver_uri)
-        shutil.copy(fwpath, python_validity_data)
+        shutil.copy(fwpath, PYTHON_VALIDITY_DATA_DIR)

--- a/dbus_service/dbus-service
+++ b/dbus_service/dbus-service
@@ -23,6 +23,7 @@ from usb import core as usb_core
 
 from validitysensor import init
 from validitysensor.db import subtype_to_string, db, SidIdentity, User
+from validitysensor.init_data_dir import PYTHON_VALIDITY_DATA_DIR, init_data_dir
 from validitysensor.sensor import sensor, RebootException
 from validitysensor.sid import sid_from_string
 from validitysensor.tls import tls
@@ -35,6 +36,7 @@ INTERFACE_NAME = 'io.github.uunicorn.Fprint.Device'
 
 loop = GLib.MainLoop()
 
+init_data_dir()
 
 class NoEnrolledPrints(dbus.DBusException):
     _dbus_error_name = 'net.reactivated.Fprint.Error.NoEnrolledPrints'
@@ -191,7 +193,7 @@ class Device(dbus.service.Object):
         return hexlify(tls.app(unhexlify(cmd))).decode()
 
 
-backoff_file = '/var/run/python-validity/backoff'
+backoff_file = PYTHON_VALIDITY_DATA_DIR + 'backoff'
 
 
 # I don't know how to tell systemd to backoff in case of multiple instance of the same template service, help!

--- a/debian/python3-validity.postinst
+++ b/debian/python3-validity.postinst
@@ -4,7 +4,6 @@ set -e
 #DEBHELPER#
 
 if [ "$1" = "configure" ]; then
-    mkdir -p /var/run/python-validity || true
     validity-sensors-firmware || true
     systemctl daemon-reload || true
     udevadm control --reload-rules || true

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='python-validity',
-      version='0.14',
+      version='0.15',
       py_modules=[],
       packages=['validitysensor'],
       scripts=[

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='python-validity',
-      version='0.15',
+      version='0.14',
       py_modules=[],
       packages=['validitysensor'],
       scripts=[

--- a/validitysensor/init.py
+++ b/validitysensor/init.py
@@ -1,6 +1,7 @@
 import atexit
 import logging
 
+from validitysensor.init_data_dir import init_data_dir
 from validitysensor.flash import read_tls_flash
 from validitysensor.init_db import init_db
 from validitysensor.init_flash import init_flash
@@ -26,6 +27,7 @@ def close():
 
 
 def open_common():
+    init_data_dir()
     init_flash()
     usb.send_init()
     tls.parse_tls_flash(read_tls_flash())

--- a/validitysensor/init_data_dir.py
+++ b/validitysensor/init_data_dir.py
@@ -1,0 +1,8 @@
+import os
+
+PYTHON_VALIDITY_DATA_DIR = '/var/run/python-validity/'
+
+def init_data_dir():
+    if not os.path.isdir(PYTHON_VALIDITY_DATA_DIR):
+        os.mkdir(PYTHON_VALIDITY_DATA_DIR)
+

--- a/validitysensor/sensor.py
+++ b/validitysensor/sensor.py
@@ -14,13 +14,14 @@ from .blobs import reset_blob
 from .db import db, SidIdentity
 from .flash import write_enable, call_cleanups, read_flash, erase_flash, write_flash_all, read_flash_all
 from .hw_tables import dev_info_lookup
+from .init_data_dir import PYTHON_VALIDITY_DATA_DIR
 from .table_types import SensorTypeInfo, SensorCaptureProg
 from .tls import tls
 from .usb import usb, CancelledException
 from .util import assert_status, unhex
 
 # TODO: this should be specific to an individual device (system may have more than one sensor)
-calib_data_path = '/var/run/python-validity/calib-data.bin'
+calib_data_path = PYTHON_VALIDITY_DATA_DIR + 'calib-data.bin'
 
 line_update_type1_devices = [
     0xB5, 0x885, 0xB3, 0x143B, 0x1055, 0xE1, 0x8B1, 0xEA, 0xE4, 0xED, 0x1825, 0x1FF5, 0x199

--- a/validitysensor/upload_fwext.py
+++ b/validitysensor/upload_fwext.py
@@ -5,10 +5,11 @@ from time import ctime
 
 from .firmware_tables import FIRMWARE_NAMES
 from .flash import write_flash_all, write_fw_signature, get_fw_info
+from .init_data_dir import PYTHON_VALIDITY_DATA_DIR
 from .sensor import reboot, write_hw_reg32, read_hw_reg32, identify_sensor
 from .usb import usb, SupportedDevices
 
-firmware_home = '/var/run/python-validity'
+firmware_home = PYTHON_VALIDITY_DATA_DIR
 
 
 def default_fwext_name():


### PR DESCRIPTION
This issue seems to be the result of the changes in #156. 

The `/var/run` directory is symlinked to `/run` which is ephemeral, and cleared on each reboot. This causes an issue where the service fails to start because the `/var/run/python-validity` dir no longer exists.

This change is quite simple, it just makes sure the directory exists before doing anything else. 

I realized after making the changes that [systemd-tmpfiles](https://manpages.ubuntu.com/manpages/bionic/man5/tmpfiles.d.5.html) exists for this purpose. If you would prefer I go with this approach I can attempt to make this change later, but in a way I like the pure python approach because we don't need extra config (I also consolidated all the usages of `/var/run/python-validity`, so that's all neatly contained in one place). 